### PR TITLE
2000年～2009年に`+%y`と`+%D`で年が1桁で出力される挙動の修正

### DIFF
--- a/date.s
+++ b/date.s
@@ -428,7 +428,7 @@ format_D:
 format_y:
 		moveq	#0,d3
 print_year:
-		moveq	#1,d4
+		moveq	#2,d4
 		moveq	#0,d0
 		move.b	year,d0
 		add.w	#1900,d0


### PR DESCRIPTION
`+%y`と`+%D`は年の下2桁を出力する書式です。
```
     %y   年の下2桁（00..99）．
     %D   ‘%m/%d/%y’と同じ．
```
しかし、2000年から2009年に使用するとゼロサプレスされ下1桁しか出力されません。

再現手順
```
# 2000年10月23日12時30分に設定
date 200010231230

date +%y
# 0

date +%D
# 10/23/0
```

このPRにより下2桁を出力するようになります。
